### PR TITLE
Remove `std` dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
+#![no_std]
 mod test;
+
+extern crate alloc;
+use alloc::vec::Vec;
 
 pub struct Queue<T: PartialOrd> {
     items: Vec<T>,


### PR DESCRIPTION
Resolves issue #1, request to make library `#[no_std]` compatible